### PR TITLE
Let todo_user depend on mail.

### DIFF
--- a/todo_user/__openerp__.py
+++ b/todo_user/__openerp__.py
@@ -2,7 +2,7 @@
     'name': 'Multiuser To-Do',
     'description': 'Extend To-Do Tasks for multiuser',
     'author': 'Daniel Reis',
-    'depends': ['todo_app'],
+    'depends': ['todo_app', 'mail'],
     'data': ['todo_view.xml', 'security/todo_access_rules.xml'],
     'demo': ['todo.task.csv', 'todo_data.xml'],
 }


### PR DESCRIPTION
I got a problem installing the `todo_user` module, which boiled down to missing a dependency on `mail`. It looks like this used to be a dependency of `todo_app` itself, but accidentally got removed in 9bf67b279abae2dc75e169a53be5d6d03f38782c. With the change in this PR, the install works again. This was the error on startup:

```
2017-10-03 17:06:44,879 88224 ERROR todo odoo.modules.registry: Failed to load registry
Traceback (most recent call last):
  File "/Users/maurits/odoo/odoo/odoo/modules/registry.py", line 82, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/Users/maurits/odoo/odoo/odoo/modules/loading.py", line 335, in load_modules
    force, status, report, loaded_modules, update_module)
  File "/Users/maurits/odoo/odoo/odoo/modules/loading.py", line 237, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks)
  File "/Users/maurits/odoo/odoo/odoo/modules/loading.py", line 131, in load_module_graph
    model_names = registry.load(cr, package)
  File "/Users/maurits/odoo/odoo/odoo/modules/registry.py", line 259, in load
    model = cls._build_model(self, cr)
  File "/Users/maurits/odoo/odoo/odoo/models.py", line 550, in _build_model
    raise TypeError("Model %r inherits from non-existing model %r." % (name, parent))
TypeError: Model 'todo.task' inherits from non-existing model 'mail.thread'.
```

BTW, the default branch on github.com should probably be 10.0 instead of 8.0.